### PR TITLE
Enhancement: Add structured logging and request tracking with Winston…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "express-rate-limit": "^8.4.1",
     "express-validator": "^7.3.2",
     "fs-extra": "^11.3.4",
-    "nodemailer": "^8.0.6"
+    "morgan": "^1.10.1",
+    "nodemailer": "^8.0.6",
+    "winston": "^3.19.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -3,6 +3,8 @@ const path = require('path');
 const { body, validationResult } = require('express-validator');
 const rateLimit = require('express-rate-limit');
 const fs = require('fs-extra');
+const morgan = require('morgan');
+const logger = require('./utils/logger');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -11,6 +13,10 @@ app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 
 // Middleware
+// Use morgan to log HTTP requests, forwarding to winston's info level
+app.use(morgan('combined', {
+    stream: { write: (message) => logger.info(message.trim()) }
+}));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(express.static(path.join(__dirname)));
@@ -83,7 +89,7 @@ app.post('/contact', contactLimiter, [
 
         res.json({ success: true, message: 'Message received successfully!' });
     } catch (err) {
-        console.error('Error saving contact submission:', err);
+        logger.error('Error saving contact submission', { error: err.message, stack: err.stack });
         res.status(500).json({ success: false, message: 'Internal server error. Please try again later.' });
     }
 });
@@ -94,6 +100,6 @@ app.use((req, res) => {
 });
 
 app.listen(PORT, () => {
-    console.log(`Server running at http://localhost:${PORT}/`);
-    console.log(`Serving templates from: ${path.join(__dirname, 'views')}`);
+    logger.info(`Server running at http://localhost:${PORT}/`);
+    logger.info(`Serving templates from: ${path.join(__dirname, 'views')}`);
 });

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,0 +1,43 @@
+const winston = require('winston');
+const path = require('path');
+
+const { combine, timestamp, printf, errors, json, colorize } = winston.format;
+
+// Format for console transport
+const consoleFormat = printf(({ level, message, timestamp, stack }) => {
+    return `${timestamp} [${level}]: ${stack || message}`;
+});
+
+// Create the logger instance
+const logger = winston.createLogger({
+    level: 'debug', // Default level
+    format: combine(
+        errors({ stack: true }), // Capture stack traces for errors
+        timestamp(),
+        json() // Output in JSON format
+    ),
+    transports: [
+        // File transport for all errors
+        new winston.transports.File({ 
+            filename: path.join(__dirname, '../error.log'), 
+            level: 'error' 
+        }),
+        // File transport for all logs
+        new winston.transports.File({ 
+            filename: path.join(__dirname, '../combined.log') 
+        }),
+    ],
+});
+
+// Add Console transport for development
+if (process.env.NODE_ENV !== 'production') {
+    logger.add(new winston.transports.Console({
+        format: combine(
+            colorize(),
+            timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+            consoleFormat
+        )
+    }));
+}
+
+module.exports = logger;


### PR DESCRIPTION
… and Morgan

#7 


## Description
This PR introduces structured logging and HTTP request tracking to the application to improve observability and debuggability in preparation for production environments. 

Previously, the application relied on native `console.log` and `console.error` methods, which lacked standardization and were difficult to aggregate. This update replaces them with a formal logging strategy using **Winston** and **Morgan**.

## Changes Made
- **Added Winston Logger**: Created a new utility (`utils/logger.js`) that configures Winston with:
  - Standardized JSON formatting, including timestamps.
  - Automatic stack trace capturing for error levels.
  - Multi-transport support: Console output (for development), `error.log` (for standalone error tracking), and `combined.log` (for comprehensive application logs).
- **Integrated Morgan Middleware**: Added `morgan` to `server.js` to automatically log incoming HTTP request methods, endpoints, status codes, and response times, piping the output directly into Winston's `info` stream.
- **Removed Raw Console Logs**: Replaced all remaining instances of `console.log` and `console.error` throughout the codebase with the new `logger.info` and `logger.error` methods.

## Acceptance Criteria Met
- [x] Logger utility created in `utils/logger.js`.
- [x] Morgan middleware added to `server.js`.
- [x] No `console.log` remaining in the server codebase.
- [x] Errors are automatically captured with stack traces in `error.log`.

## How to Test
1. Pull the branch and run `npm install` to install the new `winston` and `morgan` dependencies.
2. Start the server using `npm start`. Verify that the startup message is output in a structured format in the console.
3. Navigate to various pages (e.g., `http://localhost:3000/about`) and verify that HTTP requests are logged in the console and written to `combined.log`.
4. Trigger an intentional error (or review the codebase) to ensure errors are captured comprehensively and written to `error.log` with their associated stack trace.
